### PR TITLE
Support disabling engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,12 @@ vpath %.h $(SUBNAME)
 
 # The files to be compiled
 
+INTERNAL_HDRS = \
+	avi/EngineImpl.h \
+	avi/Config.h
+
 SRCS = $(wildcard $(SUBNAME)/*.cpp)
-HDRS = $(wildcard $(SUBNAME)/*.h)
+HDRS = $(filter-out $(INTERNAL_HDRS),$(wildcard $(SUBNAME)/*.h))
 OBJS = $(patsubst %.cpp, obj/%.o, $(notdir $(SRCS)))
 
 INCLUDES := -Iinclude $(INCLUDES)

--- a/avi/Engine.h
+++ b/avi/Engine.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "Config.h"
 #include <spine/SmartMetEngine.h>
 #include <timeseries/TimeSeries.h>
 #include <list>

--- a/avi/Engine.h
+++ b/avi/Engine.h
@@ -6,7 +6,7 @@
 #include <timeseries/TimeSeries.h>
 #include <list>
 #include <map>
-#include <pqxx/pqxx>
+#include <pqxx/result>
 
 #define stationIdQueryColumn "stationid"
 #define messageQueryColumn "message"
@@ -317,23 +317,42 @@ struct StationQueryData
                                    // returned
 };
 
-// Abstract base class for AVI engine
+/**
+ * @brief Base class for AVI engine
+ *
+ * Actual implementation and private API is intentionally hidden in derived class EngineImpl.
+ * All methods in this base class are defined inline in header file to avoid unresolved
+ * symbols during linking in case when actual AVI engine is not loaded.
+ *
+ */
 class Engine  : public SmartMet::Spine::SmartMetEngine
 {
  public:
   Engine() = default;
-  ~Engine() = default;
 
-  virtual StationQueryData queryStations(QueryOptions &queryOptions) const = 0;
+  virtual ~Engine() = default;
+
+  virtual StationQueryData queryStations(QueryOptions &queryOptions) const { unavailable(BCP); }
 
   virtual StationQueryData queryMessages(const StationIdList &stationIdList,
-                                         const QueryOptions &queryOptions) const = 0;
+                                         const QueryOptions &queryOptions) const { unavailable(BCP); }
   virtual StationQueryData &joinStationAndMessageData(const StationQueryData &stationData,
-                                                      StationQueryData &messageData) const = 0;
+                                                      StationQueryData &messageData) const { unavailable(BCP); }
 
-  virtual StationQueryData queryStationsAndMessages(QueryOptions &queryOptions) const = 0;
+  virtual StationQueryData queryStationsAndMessages(QueryOptions &queryOptions) const { unavailable(BCP); }
 
-  virtual QueryData queryRejectedMessages(const QueryOptions &queryOptions) const = 0;
+  virtual QueryData queryRejectedMessages(const QueryOptions &queryOptions) const { unavailable(BCP); }
+
+ protected:
+  virtual void init() {}
+
+  virtual void shutdown() {}
+
+ private:
+  [[noreturn]] inline void unavailable(const char* file ,int line, const char* function) const
+  {
+    throw Fmi::Exception(file, line, function, "AVI engine not available");
+  }
 };
 
 // The engine

--- a/avi/Engine.h
+++ b/avi/Engine.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Config.h"
-#include <macgyver/PostgreSQLConnection.h>
 #include <spine/SmartMetEngine.h>
 #include <timeseries/TimeSeries.h>
 #include <list>
@@ -199,7 +198,7 @@ struct Column
   std::string itsName;
 
   const std::string &getTableColumnName() const { return itsTableColumnName; }
-  friend class Engine;
+  friend class EngineImpl;
 
  private:
   std::string itsTableColumnName;
@@ -319,157 +318,31 @@ struct StationQueryData
                                    // returned
 };
 
-// The engine
-
-class Engine : public SmartMet::Spine::SmartMetEngine
+// Abstract base class for AVI engine
+class Engine  : public SmartMet::Spine::SmartMetEngine
 {
  public:
-  Engine(const std::string &theConfigFileName);
-  Engine() = delete;
+  Engine() = default;
+  ~Engine() = default;
 
-  StationQueryData queryStations(QueryOptions &queryOptions) const;
-  StationQueryData queryMessages(const StationIdList &stationIdList,
-                                 const QueryOptions &queryOptions) const;
-  StationQueryData &joinStationAndMessageData(const StationQueryData &stationData,
-                                              StationQueryData &messageData) const;
+  virtual StationQueryData queryStations(QueryOptions &queryOptions) const = 0;
 
-  StationQueryData queryStationsAndMessages(QueryOptions &queryOptions) const;
+  virtual StationQueryData queryMessages(const StationIdList &stationIdList,
+                                         const QueryOptions &queryOptions) const = 0;
+  virtual StationQueryData &joinStationAndMessageData(const StationQueryData &stationData,
+                                                      StationQueryData &messageData) const = 0;
 
-  QueryData queryRejectedMessages(const QueryOptions &queryOptions) const;
+  virtual StationQueryData queryStationsAndMessages(QueryOptions &queryOptions) const = 0;
 
- protected:
-  virtual void init();
-  void shutdown();
+  virtual QueryData queryRejectedMessages(const QueryOptions &queryOptions) const = 0;
+};
 
- private:
-  void validateTimes(const TimeOptions &timeOptions) const;
-  void validateParameters(const StringList &paramList,
-                          Validity validity,
-                          bool &messageColumnSelected) const;
-  void validateStationIds(const Fmi::Database::PostgreSQLConnection &connection,
-                          const StationIdList &stationIdList,
-                          bool debug) const;
-  void validateIcaos(const Fmi::Database::PostgreSQLConnection &connection,
-                     const StringList &icaoList,
-                     bool debug) const;
-  void validatePlaces(const Fmi::Database::PostgreSQLConnection &connection,
-                      StringList &placeNameList,
-                      bool debug) const;
-  void validateCountries(const Fmi::Database::PostgreSQLConnection &connection,
-                         const StringList &countryList,
-                         bool debug) const;
-  void validateWKTs(const Fmi::Database::PostgreSQLConnection &connection,
-                    LocationOptions &locationOptions,
-                    bool debug) const;
-  void validateMessageTypes(const Fmi::Database::PostgreSQLConnection &connection,
-                            const StringList &messageTypeList,
-                            bool debug) const;
+// The engine
 
-  const Column *getMessageTableTimeColumn(const std::string &timeColumn) const;
+class EngineImpl;
 
-  const Column *getQueryColumn(const ColumnTable tableColumns,
-                               Columns &columnList,
-                               const std::string &theQueryColumnName,
-                               bool &duplicate,
-                               int columnNumber = -1) const;
-
-  std::string buildStationQueryCoordinateExpressions(const Columns &columns) const;
-  Columns buildStationQuerySelectClause(const StringList &paramList,
-                                        bool selectStationListOnly,
-                                        bool autoSelectDistance,
-                                        std::string &selectClause) const;
-  TableMap buildMessageQuerySelectClause(QueryTable *queryTables,
-                                         const StationIdList &stationIdList,
-                                         const StringList &messageTypeList,
-                                         const StringList &paramList,
-                                         bool routeQuery,
-                                         std::string &selectClause,
-                                         bool &messageColumnSelected,
-                                         bool &distinct) const;
-
-  template <typename T>
-  void loadQueryResult(const pqxx::result &result,
-                       bool debug,
-                       T &queryData,
-                       bool distinctRows = true,
-                       int maxRows = 0) const;
-  template <typename T>
-  void executeQuery(const Fmi::Database::PostgreSQLConnection &connection,
-                    const std::string &query,
-                    bool debug,
-                    T &queryData,
-                    bool distinctRows = true,
-                    int maxRows = 0) const;
-  template <typename T>
-  void executeParamQuery(const Fmi::Database::PostgreSQLConnection &connection,
-                         const std::string &query,
-                         const std::string &queryArg,
-                         bool debug,
-                         T &queryData,
-                         bool distinctRows = true,
-                         int maxRows = 0) const;
-  template <typename T, typename T2>
-  void executeParamQuery(const Fmi::Database::PostgreSQLConnection &connection,
-                         const std::string &query,
-                         const T2 &queryArgs,
-                         bool debug,
-                         T &queryData,
-                         bool distinctRows = true,
-                         int maxRows = 0) const;
-
-  void queryStationsWithIds(const Fmi::Database::PostgreSQLConnection &connection,
-                            const StationIdList &stationIdList,
-                            const std::string &selectClause,
-                            bool debug,
-                            StationQueryData &queryData) const;
-  void queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection &connection,
-                              const StringList &icaoList,
-                              const std::string &selectClause,
-                              bool debug,
-                              StationQueryData &queryData) const;
-  void queryStationsWithCountries(const Fmi::Database::PostgreSQLConnection &connection,
-                                  const StringList &countryList,
-                                  const std::string &selectClause,
-                                  bool debug,
-                                  StationQueryData &stationQueryData) const;
-  void queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection &connection,
-                               const StringList &placeList,
-                               const std::string &selectClause,
-                               bool debug,
-                               StationQueryData &queryData) const;
-  void queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnection &connection,
-                                    const LocationOptions &locationOptions,
-                                    const StringList &messageTypes,
-                                    const std::string &selectClause,
-                                    bool debug,
-                                    StationQueryData &queryData) const;
-  void queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection &connection,
-                             const LocationOptions &locationOptions,
-                             const StringList &messageTypes,
-                             const std::string &selectClause,
-                             bool debug,
-                             StationQueryData &queryData) const;
-  void queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection &connection,
-                               const LocationOptions &locationOptions,
-                               const std::string &selectClause,
-                               bool debug,
-                               StationQueryData &queryData) const;
-
-  StationQueryData queryStations(const Fmi::Database::PostgreSQLConnection &connection,
-                                 QueryOptions &queryOptions,
-                                 bool validateQuery) const;
-  StationQueryData queryMessages(const Fmi::Database::PostgreSQLConnection &connection,
-                                 const StationIdList &stationIdList,
-                                 const QueryOptions &queryOptions,
-                                 bool validateQuery) const;
-
-  std::string itsConfigFileName;
-  std::shared_ptr<Config> itsConfig;
-
-};  // class Engine
+// ======================================================================
 
 }  // namespace Avi
 }  // namespace Engine
 }  // namespace SmartMet
-
-// ======================================================================

--- a/avi/EngineImpl.cpp
+++ b/avi/EngineImpl.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
 
-#include "Engine.h"
+#include "EngineImpl.h"
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <macgyver/Exception.h>
@@ -19,6 +19,7 @@ namespace Avi
 namespace
 {
 Fmi::TimeZonePtr& tzUTC = Fmi::TimeZonePtr::utc;
+
 
 Fmi::Database::PostgreSQLConnectionOptions mk_connection_options(Config& itsConfig)
 {
@@ -2350,7 +2351,7 @@ void sortColumnList(Columns& columns)
  */
 // ----------------------------------------------------------------------
 
-Engine::Engine(const std::string& theConfigFileName) : itsConfigFileName(theConfigFileName) {}
+EngineImpl::EngineImpl(const std::string& theConfigFileName) : itsConfigFileName(theConfigFileName) {}
 
 // ----------------------------------------------------------------------
 /*!
@@ -2362,7 +2363,7 @@ Engine::Engine(const std::string& theConfigFileName) : itsConfigFileName(theConf
  */
 // ----------------------------------------------------------------------
 
-void Engine::init()
+void EngineImpl::init()
 {
   try
   {
@@ -2380,7 +2381,7 @@ void Engine::init()
  */
 // ----------------------------------------------------------------------
 
-void Engine::shutdown()
+void EngineImpl::shutdown()
 {
   std::cout << "  -- Shutdown requested (aviengine)\n";
 }
@@ -2391,7 +2392,7 @@ void Engine::shutdown()
  */
 // ----------------------------------------------------------------------
 
-const Column* Engine::getQueryColumn(const ColumnTable tableColumns,
+const Column* EngineImpl::getQueryColumn(const ColumnTable tableColumns,
                                      Columns& columns,
                                      const string& theQueryColumnName,
                                      bool& duplicate,
@@ -2441,7 +2442,7 @@ const Column* Engine::getQueryColumn(const ColumnTable tableColumns,
  */
 // ----------------------------------------------------------------------
 
-string Engine::buildStationQueryCoordinateExpressions(const Columns& columns) const
+string EngineImpl::buildStationQueryCoordinateExpressions(const Columns& columns) const
 {
   try
   {
@@ -2470,7 +2471,7 @@ string Engine::buildStationQueryCoordinateExpressions(const Columns& columns) co
  */
 // ----------------------------------------------------------------------
 
-Columns Engine::buildStationQuerySelectClause(const StringList& paramList,
+Columns EngineImpl::buildStationQuerySelectClause(const StringList& paramList,
                                               bool selectStationListOnly,
                                               bool autoSelectDistance,
                                               string& selectClause) const
@@ -2586,7 +2587,7 @@ Columns Engine::buildStationQuerySelectClause(const StringList& paramList,
  */
 // ----------------------------------------------------------------------
 
-TableMap Engine::buildMessageQuerySelectClause(QueryTable* queryTables,
+TableMap EngineImpl::buildMessageQuerySelectClause(QueryTable* queryTables,
                                                const StationIdList& stationIdList,
                                                const StringList& messageTypeList,
                                                const StringList& paramList,
@@ -2841,7 +2842,7 @@ TableMap Engine::buildMessageQuerySelectClause(QueryTable* queryTables,
 // ----------------------------------------------------------------------
 
 template <typename T>
-void Engine::loadQueryResult(
+void EngineImpl::loadQueryResult(
     const pqxx::result &result, bool debug, T &queryData, bool distinctRows, int maxRows) const
 {
   try
@@ -3003,7 +3004,7 @@ void Engine::loadQueryResult(
 // ----------------------------------------------------------------------
 
 template <typename T>
-void Engine::executeQuery(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::executeQuery(const Fmi::Database::PostgreSQLConnection& connection,
                           const string& query,
                           bool debug,
                           T& queryData,
@@ -3032,7 +3033,7 @@ void Engine::executeQuery(const Fmi::Database::PostgreSQLConnection& connection,
 // ----------------------------------------------------------------------
 
 template <typename T>
-void Engine::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connection,
                                const string& query,
                                const string& queryArg,
                                bool debug,
@@ -3056,7 +3057,7 @@ void Engine::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connec
 }
 
 template <typename T, typename T2>
-void Engine::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connection,
                                const string& query,
                                const T2& queryArgs,
                                bool debug,
@@ -3085,7 +3086,7 @@ void Engine::executeParamQuery(const Fmi::Database::PostgreSQLConnection& connec
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnection& connection,
                                           const LocationOptions& locationOptions,
                                           const StringList& messageTypes,
                                           const string& selectClause,
@@ -3140,7 +3141,7 @@ void Engine::queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnect
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithIds(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithIds(const Fmi::Database::PostgreSQLConnection& connection,
                                   const StationIdList& stationIdList,
                                   const string& selectClause,
                                   bool debug,
@@ -3171,7 +3172,7 @@ void Engine::queryStationsWithIds(const Fmi::Database::PostgreSQLConnection& con
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection& connection,
                                     const StringList& icaoList,
                                     const string& selectClause,
                                     bool debug,
@@ -3202,7 +3203,7 @@ void Engine::queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection& c
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithCountries(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithCountries(const Fmi::Database::PostgreSQLConnection& connection,
                                         const StringList& countryList,
                                         const string& selectClause,
                                         bool debug,
@@ -3233,7 +3234,7 @@ void Engine::queryStationsWithCountries(const Fmi::Database::PostgreSQLConnectio
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection& connection,
                                      const StringList& placeNameList,
                                      const string& selectClause,
                                      bool debug,
@@ -3264,7 +3265,7 @@ void Engine::queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection& 
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection& connection,
                                    const LocationOptions& locationOptions,
                                    const StringList& messageTypes,
                                    const string& selectClause,
@@ -3299,7 +3300,7 @@ void Engine::queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection& co
  */
 // ----------------------------------------------------------------------
 
-void Engine::queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection& connection,
                                      const LocationOptions& locationOptions,
                                      const string& selectClause,
                                      bool debug,
@@ -3383,7 +3384,7 @@ Fmi::DateTime parseTime(const string &timeName, const string &timeStr)
 
 }
 
-void Engine::validateTimes(const TimeOptions& timeOptions) const
+void EngineImpl::validateTimes(const TimeOptions& timeOptions) const
 {
   try
   {
@@ -3428,7 +3429,7 @@ void Engine::validateTimes(const TimeOptions& timeOptions) const
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateParameters(const StringList& paramList,
+void EngineImpl::validateParameters(const StringList& paramList,
                                 Validity validity,
                                 bool& messageColumnSelected) const
 {
@@ -3535,7 +3536,7 @@ void Engine::validateParameters(const StringList& paramList,
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateStationIds(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validateStationIds(const Fmi::Database::PostgreSQLConnection& connection,
                                 const StationIdList& stationIdList,
                                 bool debug) const
 {
@@ -3581,7 +3582,7 @@ void Engine::validateStationIds(const Fmi::Database::PostgreSQLConnection& conne
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateIcaos(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validateIcaos(const Fmi::Database::PostgreSQLConnection& connection,
                            const StringList& icaoList,
                            bool debug) const
 {
@@ -3628,7 +3629,7 @@ void Engine::validateIcaos(const Fmi::Database::PostgreSQLConnection& connection
  */
 // ----------------------------------------------------------------------
 
-void Engine::validatePlaces(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validatePlaces(const Fmi::Database::PostgreSQLConnection& connection,
                             StringList& placeNameList,
                             bool debug) const
 {
@@ -3704,7 +3705,7 @@ void Engine::validatePlaces(const Fmi::Database::PostgreSQLConnection& connectio
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateCountries(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validateCountries(const Fmi::Database::PostgreSQLConnection& connection,
                                const StringList& countryList,
                                bool debug) const
 {
@@ -3752,7 +3753,7 @@ void Engine::validateCountries(const Fmi::Database::PostgreSQLConnection& connec
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateWKTs(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validateWKTs(const Fmi::Database::PostgreSQLConnection& connection,
                           LocationOptions& locationOptions,
                           bool debug) const
 {
@@ -3878,7 +3879,7 @@ void Engine::validateWKTs(const Fmi::Database::PostgreSQLConnection& connection,
 //
 // private
 //
-StationQueryData Engine::queryStations(const Fmi::Database::PostgreSQLConnection& connection,
+StationQueryData EngineImpl::queryStations(const Fmi::Database::PostgreSQLConnection& connection,
                                        QueryOptions& queryOptions,
                                        bool validateQuery) const
 {
@@ -4011,7 +4012,7 @@ StationQueryData Engine::queryStations(const Fmi::Database::PostgreSQLConnection
 //
 // public api stub
 //
-StationQueryData Engine::queryStations(QueryOptions& queryOptions) const
+StationQueryData EngineImpl::queryStations(QueryOptions& queryOptions) const
 {
   try
   {
@@ -4033,7 +4034,7 @@ StationQueryData Engine::queryStations(QueryOptions& queryOptions) const
  */
 // ----------------------------------------------------------------------
 
-void Engine::validateMessageTypes(const Fmi::Database::PostgreSQLConnection& connection,
+void EngineImpl::validateMessageTypes(const Fmi::Database::PostgreSQLConnection& connection,
                                   const StringList& messageTypeList,
                                   bool debug) const
 {
@@ -4092,7 +4093,7 @@ void Engine::validateMessageTypes(const Fmi::Database::PostgreSQLConnection& con
  */
 // ----------------------------------------------------------------------
 
-const Column* Engine::getMessageTableTimeColumn(const string& timeColumn) const
+const Column* EngineImpl::getMessageTableTimeColumn(const string& timeColumn) const
 {
   try
   {
@@ -4121,7 +4122,7 @@ const Column* Engine::getMessageTableTimeColumn(const string& timeColumn) const
 //
 // private
 //
-StationQueryData Engine::queryMessages(const Fmi::Database::PostgreSQLConnection& connection,
+StationQueryData EngineImpl::queryMessages(const Fmi::Database::PostgreSQLConnection& connection,
                                        const StationIdList& stationIdList,
                                        const QueryOptions& queryOptions,
                                        bool validateQuery) const
@@ -4453,7 +4454,7 @@ StationQueryData Engine::queryMessages(const Fmi::Database::PostgreSQLConnection
 //
 // public api stub
 //
-StationQueryData Engine::queryMessages(const StationIdList& stationIdList,
+StationQueryData EngineImpl::queryMessages(const StationIdList& stationIdList,
                                        const QueryOptions& queryOptions) const
 {
   try
@@ -4474,7 +4475,7 @@ StationQueryData Engine::queryMessages(const StationIdList& stationIdList,
  */
 // ----------------------------------------------------------------------
 
-StationQueryData& Engine::joinStationAndMessageData(const StationQueryData& stationData,
+StationQueryData& EngineImpl::joinStationAndMessageData(const StationQueryData& stationData,
                                                     StationQueryData& messageData) const
 {
   try
@@ -4557,7 +4558,7 @@ StationQueryData& Engine::joinStationAndMessageData(const StationQueryData& stat
  */
 // ----------------------------------------------------------------------
 
-StationQueryData Engine::queryStationsAndMessages(QueryOptions& queryOptions) const
+StationQueryData EngineImpl::queryStationsAndMessages(QueryOptions& queryOptions) const
 {
   try
   {
@@ -4689,7 +4690,7 @@ StationQueryData Engine::queryStationsAndMessages(QueryOptions& queryOptions) co
  */
 // ----------------------------------------------------------------------
 
-QueryData Engine::queryRejectedMessages(const QueryOptions& queryOptions) const
+QueryData EngineImpl::queryRejectedMessages(const QueryOptions& queryOptions) const
 {
   try
   {
@@ -4769,7 +4770,7 @@ QueryData Engine::queryRejectedMessages(const QueryOptions& queryOptions) const
 
 extern "C" void* engine_class_creator(const char* theConfigFileName, void* /* user_data */)
 {
-  return new SmartMet::Engine::Avi::Engine(theConfigFileName);
+  return new SmartMet::Engine::Avi::EngineImpl(theConfigFileName);
 }
 
 extern "C" const char* engine_name()

--- a/avi/EngineImpl.h
+++ b/avi/EngineImpl.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "Engine.h"
+#include "Config.h"
 #include <macgyver/PostgreSQLConnection.h>
+
 
 namespace SmartMet
 {

--- a/avi/EngineImpl.h
+++ b/avi/EngineImpl.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include "Engine.h"
+#include <macgyver/PostgreSQLConnection.h>
+
+namespace SmartMet
+{
+namespace Engine
+{
+namespace Avi
+{
+
+class EngineImpl : public Engine
+{
+ public:
+  EngineImpl(const std::string &theConfigFileName);
+  EngineImpl() = delete;
+
+  StationQueryData queryStations(QueryOptions &queryOptions) const override;
+  StationQueryData queryMessages(const StationIdList &stationIdList,
+                                 const QueryOptions &queryOptions) const override;
+  StationQueryData &joinStationAndMessageData(const StationQueryData &stationData,
+                                              StationQueryData &messageData) const override;
+
+  StationQueryData queryStationsAndMessages(QueryOptions &queryOptions) const override;
+
+  QueryData queryRejectedMessages(const QueryOptions &queryOptions) const override;
+
+ protected:
+  virtual void init();
+  void shutdown();
+
+ private:
+  void validateTimes(const TimeOptions &timeOptions) const;
+  void validateParameters(const StringList &paramList,
+                          Validity validity,
+                          bool &messageColumnSelected) const;
+  void validateStationIds(const Fmi::Database::PostgreSQLConnection &connection,
+                          const StationIdList &stationIdList,
+                          bool debug) const;
+  void validateIcaos(const Fmi::Database::PostgreSQLConnection &connection,
+                     const StringList &icaoList,
+                     bool debug) const;
+  void validatePlaces(const Fmi::Database::PostgreSQLConnection &connection,
+                      StringList &placeNameList,
+                      bool debug) const;
+  void validateCountries(const Fmi::Database::PostgreSQLConnection &connection,
+                         const StringList &countryList,
+                         bool debug) const;
+  void validateWKTs(const Fmi::Database::PostgreSQLConnection &connection,
+                    LocationOptions &locationOptions,
+                    bool debug) const;
+  void validateMessageTypes(const Fmi::Database::PostgreSQLConnection &connection,
+                            const StringList &messageTypeList,
+                            bool debug) const;
+
+  const Column *getMessageTableTimeColumn(const std::string &timeColumn) const;
+
+  const Column *getQueryColumn(const ColumnTable tableColumns,
+                               Columns &columnList,
+                               const std::string &theQueryColumnName,
+                               bool &duplicate,
+                               int columnNumber = -1) const;
+
+  std::string buildStationQueryCoordinateExpressions(const Columns &columns) const;
+  Columns buildStationQuerySelectClause(const StringList &paramList,
+                                        bool selectStationListOnly,
+                                        bool autoSelectDistance,
+                                        std::string &selectClause) const;
+  TableMap buildMessageQuerySelectClause(QueryTable *queryTables,
+                                         const StationIdList &stationIdList,
+                                         const StringList &messageTypeList,
+                                         const StringList &paramList,
+                                         bool routeQuery,
+                                         std::string &selectClause,
+                                         bool &messageColumnSelected,
+                                         bool &distinct) const;
+
+  template <typename T>
+  void loadQueryResult(const pqxx::result &result,
+                       bool debug,
+                       T &queryData,
+                       bool distinctRows = true,
+                       int maxRows = 0) const;
+  template <typename T>
+  void executeQuery(const Fmi::Database::PostgreSQLConnection &connection,
+                    const std::string &query,
+                    bool debug,
+                    T &queryData,
+                    bool distinctRows = true,
+                    int maxRows = 0) const;
+  template <typename T>
+  void executeParamQuery(const Fmi::Database::PostgreSQLConnection &connection,
+                         const std::string &query,
+                         const std::string &queryArg,
+                         bool debug,
+                         T &queryData,
+                         bool distinctRows = true,
+                         int maxRows = 0) const;
+  template <typename T, typename T2>
+  void executeParamQuery(const Fmi::Database::PostgreSQLConnection &connection,
+                         const std::string &query,
+                         const T2 &queryArgs,
+                         bool debug,
+                         T &queryData,
+                         bool distinctRows = true,
+                         int maxRows = 0) const;
+
+  void queryStationsWithIds(const Fmi::Database::PostgreSQLConnection &connection,
+                            const StationIdList &stationIdList,
+                            const std::string &selectClause,
+                            bool debug,
+                            StationQueryData &queryData) const;
+  void queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection &connection,
+                              const StringList &icaoList,
+                              const std::string &selectClause,
+                              bool debug,
+                              StationQueryData &queryData) const;
+  void queryStationsWithCountries(const Fmi::Database::PostgreSQLConnection &connection,
+                                  const StringList &countryList,
+                                  const std::string &selectClause,
+                                  bool debug,
+                                  StationQueryData &stationQueryData) const;
+  void queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection &connection,
+                               const StringList &placeList,
+                               const std::string &selectClause,
+                               bool debug,
+                               StationQueryData &queryData) const;
+  void queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnection &connection,
+                                    const LocationOptions &locationOptions,
+                                    const StringList &messageTypes,
+                                    const std::string &selectClause,
+                                    bool debug,
+                                    StationQueryData &queryData) const;
+  void queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection &connection,
+                             const LocationOptions &locationOptions,
+                             const StringList &messageTypes,
+                             const std::string &selectClause,
+                             bool debug,
+                             StationQueryData &queryData) const;
+  void queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection &connection,
+                               const LocationOptions &locationOptions,
+                               const std::string &selectClause,
+                               bool debug,
+                               StationQueryData &queryData) const;
+
+  StationQueryData queryStations(const Fmi::Database::PostgreSQLConnection &connection,
+                                 QueryOptions &queryOptions,
+                                 bool validateQuery) const;
+  StationQueryData queryMessages(const Fmi::Database::PostgreSQLConnection &connection,
+                                 const StationIdList &stationIdList,
+                                 const QueryOptions &queryOptions,
+                                 bool validateQuery) const;
+
+  std::string itsConfigFileName;
+  std::shared_ptr<Config> itsConfig;
+
+};  // class EngineImpl
+
+}  // namespace Avi
+}  // namespace Engine
+}  // namespace SmartMet

--- a/test/engine.cpp
+++ b/test/engine.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE "EngineClassModule"
 
-#include "Engine.h"
+#include "EngineImpl.h"
 #include "Config.h"
 
 #include <boost/test/included/unit_test.hpp>
@@ -17,6 +17,7 @@ namespace Engine
 {
 namespace Avi
 {
+
 Fmi::Database::PostgreSQLConnectionOptions mk_connection_options(Config& itsConfig)
 {
   Fmi::Database::PostgreSQLConnectionOptions opt;
@@ -109,7 +110,7 @@ const std::list<std::string> allValidRejectedMessagesParameters({"message",
 BOOST_AUTO_TEST_CASE(engine_constructor, *boost::unit_test::depends_on(""))
 {
   const std::string filename = "cnf/valid.conf";
-  Engine engine(filename);
+  EngineImpl engine(filename);
 }
 
 BOOST_AUTO_TEST_CASE(engine_singleton, *boost::unit_test::depends_on("engine_constructor"))

--- a/test/querydata.cpp
+++ b/test/querydata.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE "QueryDataClassModule"
 
 #include "Config.h"
-#include "Engine.h"
+#include "EngineImpl.h"
 
 #include <boost/test/included/unit_test.hpp>
 #include <typeinfo>

--- a/test/stationquerydata.cpp
+++ b/test/stationquerydata.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE "StationQueryDataClassModule"
 
 #include "Config.h"
-#include "Engine.h"
+#include "EngineImpl.h"
 
 #include <boost/test/included/unit_test.hpp>
 #include <typeinfo>


### PR DESCRIPTION
1. Support disabling engine
2. Ensure that present of engine public AVI references do not cause unresolved references in case when engine is not loaded