### PR TITLE
Fix swapped X accessors on BBox (xmin/xmax)

### DIFF
--- a/avi/Engine.h
+++ b/avi/Engine.h
@@ -28,9 +28,9 @@ struct BBox
   {
   }
 
-  double getXMin() const { return itsEast; }
+  double getXMin() const { return itsWest; }
   double getYMin() const { return itsSouth; }
-  double getXMax() const { return itsWest; }
+  double getXMax() const { return itsEast; }
   double getYMax() const { return itsNorth; }
 
   double itsWest = 0;


### PR DESCRIPTION
## Summary
`BBox::getXMin()` and `BBox::getXMax()` in `avi/Engine.h` are swapped: `getXMin()` returns `itsEast` and `getXMax()` returns `itsWest`. Construction is fine — `BBox(theWest, theEast, theSouth, theNorth)` stores each parameter correctly — but anyone reading via the public accessors gets `xmin > xmax`.

The Y accessors are already correct.

## Why it matters
`smartmet-plugin-edr/edr/EDRMetaData.cpp:855-864` (the FIR-derived bbox path in `setAviStations`) is the only outside consumer of these accessors. It feeds the swapped values straight into the GeoJSON `bbox` of the AVI `/collections/<id>/locations` "all" feature.

Reproducible against FMI production:
```
GET https://aviation.fmi.fi/<apikey>/edr/collections/sigmet/locations
→ "all": { "bbox": [31.5867, 59, 19.0867, 70.0961], ... }   // xmin > xmax
```
Helsinki FIR's actual extents are `19.0867° E .. 31.5867° E`, `59° N .. 70.0961° N`. Same swap reproduced on a fresh test deployment with Tallinn FIR.

## Why nobody has noticed
The polygon geometry on the map comes from `ST_AsGeoJSON(ST_ForcePolygonCCW(areageom))` in `EngineImpl::loadFIRAreas` — completely separate code path. Map clients render the polygon and either ignore the `bbox` or compute their own from features, so a backwards bbox is invisible to humans.

## Why this is safe
The engine's own SQL builder bypasses the buggy accessors entirely: when emitting `ST_MakeEnvelope`, `EngineImpl.cpp:650-651` reads `bbox.itsWest`, `bbox.itsEast` directly. The bbox-driven station filter (used by `smartmet-plugin-wms`'s MetarLayer and by EDR `avi.collections` bbox configs) is therefore correct today and stays correct after the fix.

Audit of every dependent repo:
| consumer | uses `getXMin/getXMax`? |
|---|---|
| `smartmet-engine-avi` (internal) | No — direct fields |
| `smartmet-plugin-avi` | No — only constructs BBox |
| `smartmet-plugin-edr` | **Yes** — the bug site (`EDRMetaData.cpp:855-864`) |
| `smartmet-plugin-wms` | No — `MetarLayer.cpp:773` constructs BBox; engine consumes via fields |
| `smartmet-plugin-timeseries` | No — does not depend on `smartmet-engine-avi` |

So the fix purely repairs the EDR `/locations` bbox metadata; no other code path can change behavior.

## Test plan
- [x] Build clean.
- [x] WMS MetarLayer query (which uses BBox-by-area) returns the same set of stations as before — verified by code-path analysis (engine reads `itsWest/itsEast` directly).
- [x] EDR `/edr/collections/sigmet/locations` `all` feature: `bbox` order changes from `[xmax, ymin, xmin, ymax]` to `[xmin, ymin, xmax, ymax]`. Y values unchanged. Numbers themselves unchanged, only swapped pair fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)