### PR TITLE
Fix missing FIR-table join in non-icao/country station queries

### DIFF
--- a/avi/EngineImpl.cpp
+++ b/avi/EngineImpl.cpp
@@ -3341,6 +3341,7 @@ void EngineImpl::queryStationsWithCoordinates(const Fmi::Database::PostgreSQLCon
 void EngineImpl::queryStationsWithIds(const Fmi::Database::PostgreSQLConnection& connection,
                                       const StationIdList& stationIdList,
                                       const string& selectClause,
+                                      bool firIdQuery,
                                       bool debug,
                                       StationQueryData& stationQueryData) const
 {
@@ -3350,12 +3351,18 @@ void EngineImpl::queryStationsWithIds(const Fmi::Database::PostgreSQLConnection&
 
     ostringstream whereClause;
 
+    string fromClause(string(" FROM avidb_stations ") + stationTableAlias);
+
     buildStationQueryWhereClause(stationIdList, whereClause);
 
-    executeQuery<StationQueryData>(connection,
-                                   selectClause + " FROM avidb_stations " + whereClause.str(),
-                                   debug,
-                                   stationQueryData);
+    if (firIdQuery)
+    {
+      fromClause += (string(",") + firTableName + " AS " + firTableAlias);
+      whereClause << " AND " << firTableJoin;
+    }
+
+    executeQuery<StationQueryData>(
+        connection, selectClause + fromClause + " " + whereClause.str(), debug, stationQueryData);
   }
   catch (...)
   {
@@ -3454,6 +3461,7 @@ void EngineImpl::queryStationsWithCountries(const Fmi::Database::PostgreSQLConne
 void EngineImpl::queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection& connection,
                                          const StringList& placeNameList,
                                          const string& selectClause,
+                                         bool firIdQuery,
                                          bool debug,
                                          StationQueryData& stationQueryData) const
 {
@@ -3463,13 +3471,19 @@ void EngineImpl::queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnecti
 
     ostringstream whereClause;
 
+    string fromClause(string(" FROM avidb_stations ") + stationTableAlias);
+
     buildStationQueryWhereClause(
         connection, "UPPER(BTRIM(name))", placeNameList, "", {}, whereClause);
 
-    executeQuery<StationQueryData>(connection,
-                                   selectClause + " FROM avidb_stations " + whereClause.str(),
-                                   debug,
-                                   stationQueryData);
+    if (firIdQuery)
+    {
+      fromClause += (string(",") + firTableName + " AS " + firTableAlias);
+      whereClause << " AND " << firTableJoin;
+    }
+
+    executeQuery<StationQueryData>(
+        connection, selectClause + fromClause + " " + whereClause.str(), debug, stationQueryData);
   }
   catch (...)
   {
@@ -3524,6 +3538,7 @@ void EngineImpl::queryStationsWithWKTs(const Fmi::Database::PostgreSQLConnection
 void EngineImpl::queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection& connection,
                                          const LocationOptions& locationOptions,
                                          const string& selectClause,
+                                         bool firIdQuery,
                                          bool debug,
                                          StationQueryData& stationQueryData) const
 {
@@ -3533,13 +3548,22 @@ void EngineImpl::queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnecti
 
     ostringstream whereClause;
 
-    buildStationQueryWhereClause(
-        locationOptions.itsBBoxes, locationOptions.itsMaxDistance, whereClause);
+    string fromClause(string(" FROM avidb_stations ") + stationTableAlias);
 
-    executeQuery<StationQueryData>(connection,
-                                   selectClause + " FROM avidb_stations " + whereClause.str(),
-                                   debug,
-                                   stationQueryData);
+    buildStationQueryWhereClause(locationOptions.itsBBoxes,
+                                 locationOptions.itsMaxDistance,
+                                 whereClause,
+                                 "WHERE ",
+                                 stationTableAlias);
+
+    if (firIdQuery)
+    {
+      fromClause += (string(",") + firTableName + " AS " + firTableAlias);
+      whereClause << " AND " << firTableJoin;
+    }
+
+    executeQuery<StationQueryData>(
+        connection, selectClause + fromClause + " " + whereClause.str(), debug, stationQueryData);
   }
   catch (...)
   {
@@ -4239,6 +4263,7 @@ StationQueryData EngineImpl::queryStations(const Fmi::Database::PostgreSQLConnec
       queryStationsWithIds(connection,
                            locationOptions.itsStationIds,
                            selectClause,
+                           firIdQuery,
                            queryOptions.itsDebug,
                            stationQueryData);
 
@@ -4263,6 +4288,7 @@ StationQueryData EngineImpl::queryStations(const Fmi::Database::PostgreSQLConnec
       queryStationsWithPlaces(connection,
                               locationOptions.itsPlaces,
                               selectClause,
+                              firIdQuery,
                               queryOptions.itsDebug,
                               stationQueryData);
 
@@ -4275,8 +4301,12 @@ StationQueryData EngineImpl::queryStations(const Fmi::Database::PostgreSQLConnec
                             stationQueryData);
 
     if (!locationOptions.itsBBoxes.empty())
-      queryStationsWithBBoxes(
-          connection, locationOptions, selectClause, queryOptions.itsDebug, stationQueryData);
+      queryStationsWithBBoxes(connection,
+                              locationOptions,
+                              selectClause,
+                              firIdQuery,
+                              queryOptions.itsDebug,
+                              stationQueryData);
 
     if (!queryOptions.itsMessageColumnSelected)
     {

--- a/avi/EngineImpl.h
+++ b/avi/EngineImpl.h
@@ -114,6 +114,7 @@ class EngineImpl : public Engine
   void queryStationsWithIds(const Fmi::Database::PostgreSQLConnection &connection,
                             const StationIdList &stationIdList,
                             const std::string &selectClause,
+                            bool firIdQuery,
                             bool debug,
                             StationQueryData &queryData) const;
   void queryStationsWithIcaos(const Fmi::Database::PostgreSQLConnection &connection,
@@ -132,6 +133,7 @@ class EngineImpl : public Engine
   void queryStationsWithPlaces(const Fmi::Database::PostgreSQLConnection &connection,
                                const StringList &placeList,
                                const std::string &selectClause,
+                               bool firIdQuery,
                                bool debug,
                                StationQueryData &queryData) const;
   void queryStationsWithCoordinates(const Fmi::Database::PostgreSQLConnection &connection,
@@ -149,6 +151,7 @@ class EngineImpl : public Engine
   void queryStationsWithBBoxes(const Fmi::Database::PostgreSQLConnection &connection,
                                const LocationOptions &locationOptions,
                                const std::string &selectClause,
+                               bool firIdQuery,
                                bool debug,
                                StationQueryData &queryData) const;
 


### PR DESCRIPTION
## Summary

Five of the seven `queryStationsWith*` backends never join the FIR
table even when the dispatcher tells them to (`firIdQuery = true`).
When the EDR plugin asks for AVI collection metadata it includes
`fi.firid` in the SELECT — so calling those collections with a
`bbox` (or `stationId` / `place`) filter aborts with:

```
missing FROM-clause entry for table \"fi\"
```

`queryStationsWithIcaos` / `queryStationsWithCountries` already get
this right: they take a `bool firIdQuery` parameter and conditionally
append `,icao_fir_yhdiste AS fi` to FROM and the join predicate to
WHERE. The fix extends that exact pattern to the three trivial paths
that have the same shape:

- `queryStationsWithIds`
- `queryStationsWithPlaces`
- `queryStationsWithBBoxes`

`queryStationsWithBBoxes` additionally passes `stationTableAlias` to
`buildStationQueryWhereClause` so the bbox geometry comparison emits
`st.geom` rather than the unaliased `geom` (otherwise it could be
ambiguous once the FIR table is joined).

The dispatcher (`queryStations`) is updated to forward `firIdQuery` to
all three.

## Why this PR is incremental

`queryStationsWithCoordinates` and `queryStationsWithWKTs` have the
same trap, but they build their FROM clauses through dedicated
helpers (`buildStationQueryFromWhereClause` /
`buildStationQueryFromWhereOrderByClause`) that are already entangled
with nearest-station-rank wrapping, route-scope handling, FIR-scope
WKT geometry, etc. Patching those helpers safely is a meatier change
than the simple plumbing here, so I've left them as a follow-up — the
\"caveat\" they currently produce is the same `missing FROM-clause`
error.

## Behavior

No behavior change when `firIdQuery = false` (the common path):
- The new `fromClause` is `\" FROM avidb_stations \" + stationTableAlias`,
  i.e. `\" FROM avidb_stations st\"` — the existing query did `\" FROM avidb_stations \"` (unaliased), which is identical for column resolution.
- The conditional FIR join only fires when `firIdQuery = true`, in which case the
  query gains `,icao_fir_yhdiste AS fi … AND ST_Contains(fi.areageom,st.geom)`.

## Test plan

- [x] Manual: against a populated avidb (Estonian aerodromes + Tallinn FIR), the EDR plugin's `/edr/collections/metar?bbox=...` query no longer returns `missing FROM-clause entry for table \"fi\"`.
- [ ] CI: build and unit tests on rhel9/rhel10.

## Repro before the fix

EDR `avi.collections` config:

```text
{ name = \"metar\"; bboxes = [\"21.5,57.5,28.5,60.0\"]; }
```

Engine log:

```
ERROR: missing FROM-clause entry for table \"fi\"
LINE 1: SELECT fi.firid, ... FROM avidb_stations WHERE ...
                                                         ^
```

## Notes

The chart documentation in `fmidev/helm-charts` currently warns users
to use `countries` / `icaos` instead of `bbox` for AVI collections;
once this lands the warning can be lifted for `bbox` (and `stationId`,
`place`). The `coordinates` / `wkts` warning will need the follow-up
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)